### PR TITLE
Fix: wrong grad calculations and tiny issues in training.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -21,10 +21,10 @@ class TestDotProduct(unittest.TestCase):
         c = st.dot_product(a, b)  # 2.5
         c.backward()
 
-        e_a_grad = np.array([[1.25, 1.25, 2.5]])  # c * b
+        e_a_grad = np.array([[0.5, 0.5, 1.0]])  # c * b
         assert_allclose(a.grad, e_a_grad)
 
-        e_b_grad = np.array([[2.5, -5.0, 7.5]]).T  # c * a
+        e_b_grad = np.array([[1.0, -2.0, 3.0]]).T  # c * a
         assert_allclose(b.grad, e_b_grad)
 
     def test_matrix_vector_fwd(self):
@@ -60,7 +60,7 @@ class TestAggregation(unittest.TestCase):
         b = st.sui_sum(a)
         b.backward()
 
-        e_a_grad = np.array([[1.5, 1.5, 1.5]]).T
+        e_a_grad = np.array([[1.0, 1.0, 1.0]]).T
         assert_allclose(a.grad, e_a_grad)
 
 
@@ -159,7 +159,7 @@ class TestBackpropagation(unittest.TestCase):
         c = st.sui_sum(b)
         c.backward()
 
-        e_a_grad = np.array([[4.0, 0.0, 4.0]]).T
+        e_a_grad = np.array([[1.0, 0.0, 1.0]]).T
 
         assert_allclose(a.grad, e_a_grad)
 
@@ -171,8 +171,8 @@ class TestBackpropagation(unittest.TestCase):
         d = st.sui_sum(c)
         d.backward()
 
-        e_a_grad = np.array([[8.0, 8.0, 8.0]]).T
-        e_b_grad = np.array([[8.0, 8.0, 8.0]]).T
+        e_a_grad = np.array([[1.0, 1.0, 1.0]]).T
+        e_b_grad = np.array([[1.0, 1.0, 1.0]]).T
 
         assert_allclose(a.grad, e_a_grad)
         assert_allclose(b.grad, e_b_grad)

--- a/training.py
+++ b/training.py
@@ -71,6 +71,7 @@ def train_model(model, xs, ys, opt, nb_epochs):
     for epoch in range(nb_epochs):
         epoch_loss = 0.0
         for x, y in zip(xs, ys):
+            opt.zero_grad()
             x = st.Tensor(np.array([[x]]).T)
             y = st.Tensor(np.array([[y]]).T)
             predicted = model.forward(x)
@@ -135,22 +136,22 @@ def main():
 
     m1 = LinearModel(1, 1)
     opt1 = st.StochasticGradientDescent(m1.parameters(), lr=1e-4)
-    train_model(m1, train_xs, train_ys, opt1, nb_epochs=200)
+    train_model(m1, train_xs, train_ys, opt1, nb_epochs=args.nb_epochs)
     print('Train loss:', evaluate_model(m1, train_xs, train_ys), 'eval:', evaluate_model(m1, eval_xs, eval_ys))
 
     m2 = NonLinearModel(1, 5, 1)
     opt2 = st.StochasticGradientDescent(m2.parameters(), lr=1e-5)
-    train_model(m2, train_xs, train_ys, opt2, nb_epochs=200)
+    train_model(m2, train_xs, train_ys, opt2, nb_epochs=args.nb_epochs)
     print('Train loss:', evaluate_model(m2, train_xs, train_ys), 'eval:', evaluate_model(m2, eval_xs, eval_ys))
 
     m3 = NonLinearModel(1, 20, 1)
     opt3 = st.StochasticGradientDescent(m3.parameters(), lr=1e-4)
-    train_model(m3, train_xs, train_ys, opt3, nb_epochs=200)
+    train_model(m3, train_xs, train_ys, opt3, nb_epochs=args.nb_epochs)
     print('Train loss:', evaluate_model(m3, train_xs, train_ys), 'eval:', evaluate_model(m3, eval_xs, eval_ys))
 
     m4 = NonLinearModel(1, 50, 1)
     opt4 = st.StochasticGradientDescent(m4.parameters(), lr=1e-4)
-    train_model(m4, train_xs, train_ys, opt4, nb_epochs=200)
+    train_model(m4, train_xs, train_ys, opt4, nb_epochs=args.nb_epochs)
     print('Train loss:', evaluate_model(m4, train_xs, train_ys), 'eval:', evaluate_model(m4, eval_xs, eval_ys))
 
     if args.do_plots:


### PR DESCRIPTION
Fixes wrong grad calculations in `test.py` and adds `opt.zero_grad()` in `training.py`, also changes the `nb_epochs` argument to propagate correctly. 

Validity of tests compared against torch equivalent, [Validation script](https://gist.github.com/S1ro1/0fefc8972ebab03463beccd08ab3c162). 